### PR TITLE
Remove login protection from open-jade-data

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -7,16 +7,9 @@ http {
         listen 80;
         server_name _;
 
-        location = /version.txt {
-            autoindex         off;
-            alias /src/version.txt;
-         }
-
         location / {
             autoindex         off;
             alias /src/;
-            auth_basic "Restricted content";
-            auth_basic_user_file /etc/nginx/users_passwd/.htpasswd;
         }
     }
 }


### PR DESCRIPTION
## Why 
The launch will be on the 15th of May and it will no longer need to be protected by login.

## What
- [x] remove authentication from (staging.)openjadedata.org
- [x] make revenues tool repository public
-  [x] make licenses tool repo public

## Notes
This will have to be done on the 15th of May, approximately at 3:30(UTC +6.3)